### PR TITLE
Add functions for post-mortem plotting across experiments

### DIFF
--- a/src/gen_experiments/__init__.py
+++ b/src/gen_experiments/__init__.py
@@ -220,15 +220,18 @@ feat_params = {
     "cubic": ND({"featcls": "Polynomial", "degree": 3}),
     "testweak": ND({"featcls": "WeakPDELibrary"}),  # needs work
     "pde": ParamDetails(
-        ND({
-            "featcls": "pde",
-            "library_functions": [lambda x: x],
-            "function_names": [lambda x: x],
-            "derivative_order": 2,
-            "spatial_grid": np.arange(0, 10, 0.1),
-            "include_interaction": False
-        }),[ps]
-    )
+        ND(
+            {
+                "featcls": "pde",
+                "library_functions": [lambda x: x],
+                "function_names": [lambda x: x],
+                "derivative_order": 2,
+                "spatial_grid": np.arange(0, 10, 0.1),
+                "include_interaction": False,
+            }
+        ),
+        [ps],
+    ),
 }
 opt_params = {
     "test": ND({"optcls": "STLSQ"}),

--- a/src/gen_experiments/__main__.py
+++ b/src/gen_experiments/__main__.py
@@ -37,7 +37,7 @@ args = parser.parse_args()
 ex, group = gen_experiments.experiments[args.experiment]
 seed = args.seed
 params = gen_experiments.lookup_params(args.param)
-trials_folder = Path(__file__).parent.absolute() / "trials"
+trials_folder = gen_experiments.utils.TRIALS_FOLDER
 if not trials_folder.exists():
     trials_folder.mkdir(parents=True)
 mitosis.run(

--- a/src/gen_experiments/gridsearch.py
+++ b/src/gen_experiments/gridsearch.py
@@ -151,6 +151,7 @@ def run(
 
     main_metric_ind = metrics.index("main") if "main" in metrics else 0
     return {
+        "system": ex_name,
         "plot_data": plot_data,
         "series_data": {
             name: data
@@ -159,7 +160,8 @@ def run(
             )
         },
         "metrics": metrics,
-        "grid_axes": {name: data for name, data in zip(grid_params, grid_vals)},
+        "grid_params": grid_params,
+        "grid_vals": grid_vals,
         "main": max(grid[main_metric_ind].max() for grid in series_searches),
     }
 

--- a/src/gen_experiments/utils.py
+++ b/src/gen_experiments/utils.py
@@ -848,6 +848,37 @@ def _setup_summary_fig(
     return fig, subs
 
 
+def plot_experiment_across_gridpoint(hexstr: str, *args: tuple[str, dict]) -> None:
+    """Plot a single experiment's test across multiple gridpoints
+
+    Arguments:
+        hexstr: hexadecimal suffix for the experiment's result file.
+        args (param name, params): From which gridpoints to load
+            data, described as a local name and the paramters defining
+            the gridpoint to match.
+    """
+    fig, axs = _setup_summary_fig(len(args))
+    fig.suptitle("How well does a smoothing method perform across ODEs?")
+    for ax, (p_name, params) in zip(axs.reshape(-1), args):
+        results = load_results(hexstr)
+        for trajectory in results["plot_data"]:
+            if params == trajectory["params"]:
+                ax.set_title(p_name)
+                if trajectory["data"]["x_test"].shape[1]== 2:
+                    plot_func = _plot_test_sim_data_2d
+                else:
+                    plot_func = _plot_test_sim_data_3d
+                plot_func(
+                    [ax, ax],
+                    trajectory["data"]["x_test"],
+                    trajectory["data"]["x_sim"],
+                )
+                break
+        else:
+            warn(f"Did not find a parameter match for {p_name} experiment")
+    ax.legend()
+
+
 def plot_point_across_experiments(params: dict, *args: tuple[str, str], style) -> None:
     """Plot a single parameter's training or test across multiple experiments
 

--- a/src/gen_experiments/utils.py
+++ b/src/gen_experiments/utils.py
@@ -1,8 +1,9 @@
+from pathlib import Path
 from collections import defaultdict
 from dataclasses import dataclass, field
 from itertools import chain
 from types import ModuleType
-from typing import Sequence, Mapping, Optional, Collection, Callable
+from typing import Any, Sequence, Mapping, Optional, Collection, Callable, TypedDict
 from math import ceil
 from warnings import warn
 
@@ -18,6 +19,7 @@ import auto_ks as aks
 INTEGRATOR_KEYWORDS = {"rtol": 1e-12, "method": "LSODA", "atol": 1e-12}
 PAL = sns.color_palette("Set1")
 PLOT_KWS = dict(alpha=0.7, linewidth=3)
+TRIALS_FOLDER = Path(__file__).parent.absolute() / "trials"
 
 
 def gen_data(
@@ -779,3 +781,30 @@ def kalman_generalized_cv(
     est_Q = np.linalg.inv(params.W_neg_sqrt @ params.W_neg_sqrt.T)
     est_alpha = 1 / (est_Q / Qi).mean()
     return est_alpha
+
+
+class GridPointData(TypedDict):
+    x_train: np.ndarray
+    x_true: np.ndarray
+    smooth_train: np.ndarray
+    x_test: np.ndarray
+    t_sim: np.ndarray
+    x_sim: np.ndarray
+
+
+class PlotData(TypedDict):
+    params: dict[str, Any]
+    data: GridPointData
+
+
+class Results(TypedDict):
+    plot_data: list[PlotData]
+    series_data: dict[str, list[np.ndarray]]
+    metrics: list[str]
+    grid_axes: dict[str, Collection[float]]
+    main: float
+
+
+def load_results(hexstr: str) -> Results:
+    with open(TRIALS_FOLDER / f"results_{hexstr}.npy", "rb") as f:
+        return np.load(f, allow_pickle=True)[()]

--- a/src/gen_experiments/utils.py
+++ b/src/gen_experiments/utils.py
@@ -834,16 +834,18 @@ def load_results(hexstr: str) -> Results:
         return np.load(f, allow_pickle=True)[()]
 
 
-def _setup_summary_fig(n_subplots) -> tuple[plt.Figure, np.ndarray[plt.Axes]]:
-    n_rows = max(n_subplots // 3, (n_subplots + 2) // 3)
-    fig, subplots = plt.subplots(
-        n_rows,
-        min(n_subplots, 3),
-        sharey="row",
-        sharex="col",
-        squeeze=False,
-    )
-    return fig, subplots
+def _setup_summary_fig(
+        n_sub: int, type: str="axes"
+) -> tuple[plt.Figure, np.ndarray[plt.Axes | plt.Figure]]:
+    """Create neatly laid-out arrangements of subplots or subfigures"""
+    n_rows = max(n_sub // 3, (n_sub + 2) // 3)
+    size = (n_rows, min(n_sub, 3))
+    if type.lower() == "figure":
+        fig = plt.figure()
+        subs = fig.subfigures(*size, squeeze=False)
+    elif type.lower() == "axes":
+        fig, subs = plt.subplots(*size, sharey="row", sharex="col", squeeze=False)
+    return fig, subs
 
 
 def plot_summary_smoothing(params: dict, *args: tuple[str, str]) -> None:

--- a/src/gen_experiments/utils.py
+++ b/src/gen_experiments/utils.py
@@ -527,14 +527,19 @@ def plot_training_data(
     x_train: np.ndarray, x_true: np.ndarray, x_smooth: np.ndarray
 ):
     """Plot training data (and smoothed training data, if different)."""
-    fig, axs = plt.subplots(1, 2, figsize=(12, 6))
-    plot_training_trajectory(axs[0], x_train, x_true, x_smooth)
-    axs[0].legend()
-    axs[0].set(title="Training data")
-    axs[1].loglog(np.abs(scipy.fft.rfft(x_train, axis=0)) / np.sqrt(len(x_train)))
-    axs[1].set(title="Training Data Absolute Spectral Density")
-    axs[1].set(xlabel="Wavenumber")
-    axs[1].set(ylabel="Magnitude")
+    fig = plt.figure(figsize=(12, 6))
+    if x_train.shape[-1] == 2:
+        ax0 = fig.add_subplot(1, 2, 1)
+    elif x_train.shape[-1] == 3:
+        ax0 = fig.add_subplot(1, 2, 1, projection="3d")
+    plot_training_trajectory(ax0, x_train, x_true, x_smooth)
+    ax0.legend()
+    ax0.set(title="Training data")
+    ax1 = fig.add_subplot(1, 2, 2)
+    ax1.loglog(np.abs(scipy.fft.rfft(x_train, axis=0)) / np.sqrt(len(x_train)))
+    ax1.set(title="Training Data Absolute Spectral Density")
+    ax1.set(xlabel="Wavenumber")
+    ax1.set(ylabel="Magnitude")
     return fig
 
 

--- a/src/gen_experiments/utils.py
+++ b/src/gen_experiments/utils.py
@@ -571,18 +571,18 @@ def plot_test_sim_data_1d_panel(
 def _plot_test_sim_data_2d(
     axs: Annotated[Sequence[plt.Axes], "len=2"], x_test: np.ndarray, x_sim: np.ndarray
 ) -> None:
-    axs[0].plot(x_test[:, 0], x_test[:, 1], "k")
+    axs[0].plot(x_test[:, 0], x_test[:, 1], "k", label="True Trajectory")
     axs[0].set(xlabel="$x_0$", ylabel="$x_1$")
-    axs[1].plot(x_sim[:, 0], x_sim[:, 1], "r--")
+    axs[1].plot(x_sim[:, 0], x_sim[:, 1], "r--", label="Simulation")
     axs[1].set(xlabel="$x_0$", ylabel="$x_1$")
 
 
 def _plot_test_sim_data_3d(
     axs: Annotated[Sequence[plt.Axes], "len=3"], x_test: np.ndarray, x_sim: np.ndarray
 ) -> None:
-    axs[0].plot(x_test[:, 0], x_test[:, 1], x_test[:, 2], "k")
+    axs[0].plot(x_test[:, 0], x_test[:, 1], x_test[:, 2], "k", label="True Trajectory")
     axs[0].set(xlabel="$x_0$", ylabel="$x_1$", zlabel="$x_2$")
-    axs[1].plot(x_sim[:, 0], x_sim[:, 1], x_sim[:, 2], "r--")
+    axs[1].plot(x_sim[:, 0], x_sim[:, 1], x_sim[:, 2], "r--", label="Simulation")
     axs[1].set(xlabel="$x_0$", ylabel="$x_1$", zlabel="$x_2$")
 
 
@@ -877,20 +877,21 @@ def plot_summary_simulation(params: dict, *args: tuple[str, str]) -> None:
     """
     fig, axs = _setup_summary_fig(len(args))
     fig.suptitle("How well does a smoothing method perform across ODEs?")
-
     for ax, (ode_name, hexstr) in zip(axs.reshape(-1), args):
         results = load_results(hexstr)
         for trajectory in results["plot_data"]:
             if params == trajectory["params"]:
                 ax.set_title(ode_name)
-                plot_training_trajectory(
-                    ax,
-                    trajectory["data"]["x_train"],
-                    trajectory["data"]["x_true"],
-                    trajectory["data"]["smooth_train"]
+                if trajectory["data"]["x_test"].shape[1]== 2:
+                    plot_func = _plot_test_sim_data_2d
+                else:
+                    plot_func = _plot_test_sim_data_3d
+                plot_func(
+                    [ax, ax],
+                    trajectory["data"]["x_test"],
+                    trajectory["data"]["x_sim"],
                 )
                 break
-
         else:
             warn(f"Did not find a parameter match for {ode_name} experiment")
     ax.legend()

--- a/src/gen_experiments/utils.py
+++ b/src/gen_experiments/utils.py
@@ -462,70 +462,57 @@ def _make_model(
     )
 
 
-def plot_training_data(
-    last_train: np.ndarray, last_train_true: np.ndarray, smoothed_last_train: np.ndarray
-):
-    """Plot training data (and smoothed training data, if different)."""
-    fig = plt.figure(figsize=(12, 6))
-    if last_train.shape[1] == 2:
-        ax = fig.add_subplot(1, 2, 1)
+def plot_training_trajectory(
+    ax: plt.Axes, x_train: np.ndarray, x_true: np.ndarray, x_smooth: np.ndarray
+) -> None:
+    """Plot a single training trajectory"""
+    if x_train.shape[1] == 2:
         ax.plot(
-            last_train_true[:, 0],
-            last_train_true[:, 1],
-            ".",
-            label="True values",
-            color=PAL[0],
-            **PLOT_KWS,
+            x_true[:, 0], x_true[:, 1], ".", label= "True", color=PAL[0], **PLOT_KWS
         )
         ax.plot(
-            last_train[:, 0],
-            last_train[:, 1],
-            ".",
-            label="Measured values",
-            color=PAL[1],
-            **PLOT_KWS,
+            x_train[:, 0], x_train[:, 1], ".", label="Measured", color=PAL[1], **PLOT_KWS,
         )
         if (
-            np.linalg.norm(smoothed_last_train - last_train) / smoothed_last_train.size
+            np.linalg.norm(x_smooth - x_train) / x_smooth.size
             > 1e-12
         ):
             ax.plot(
-                smoothed_last_train[:, 0],
-                smoothed_last_train[:, 1],
+                x_smooth[:, 0],
+                x_smooth[:, 1],
                 ".",
-                label="Smoothed values",
+                label="Smoothed",
                 color=PAL[2],
                 **PLOT_KWS,
             )
         ax.set(xlabel="$x_0$", ylabel="$x_1$")
-    elif last_train.shape[1] == 3:
-        ax = fig.add_subplot(1, 2, 1, projection="3d")
+    elif x_train.shape[1] == 3:
         ax.plot(
-            last_train_true[:, 0],
-            last_train_true[:, 1],
-            last_train_true[:, 2],
+            x_true[:, 0],
+            x_true[:, 1],
+            x_true[:, 2],
             color=PAL[0],
             label="True values",
             **PLOT_KWS,
         )
 
         ax.plot(
-            last_train[:, 0],
-            last_train[:, 1],
-            last_train[:, 2],
+            x_train[:, 0],
+            x_train[:, 1],
+            x_train[:, 2],
             ".",
             color=PAL[1],
             label="Measured values",
             alpha=0.3,
         )
         if (
-            np.linalg.norm(smoothed_last_train - last_train) / smoothed_last_train.size
+            np.linalg.norm(x_smooth - x_train) / x_smooth.size
             > 1e-12
         ):
             ax.plot(
-                smoothed_last_train[:, 0],
-                smoothed_last_train[:, 1],
-                smoothed_last_train[:, 2],
+                x_smooth[:, 0],
+                x_smooth[:, 1],
+                x_smooth[:, 2],
                 ".",
                 color=PAL[2],
                 label="Smoothed values",
@@ -534,14 +521,22 @@ def plot_training_data(
         ax.set(xlabel="$x$", ylabel="$y$", zlabel="$z$")
     else:
         raise ValueError("Can only plot 2d or 3d data.")
-    ax.set(title="Training data")
-    ax.legend()
-    ax = fig.add_subplot(1, 2, 2)
-    ax.loglog(np.abs(scipy.fft.rfft(last_train, axis=0)) / np.sqrt(len(last_train)))
-    ax.set(title="Training Data Absolute Spectral Density")
-    ax.set(xlabel="Wavenumber")
-    ax.set(ylabel="Magnitude")
+
+
+def plot_training_data(
+    x_train: np.ndarray, x_true: np.ndarray, x_smooth: np.ndarray
+):
+    """Plot training data (and smoothed training data, if different)."""
+    fig, axs = plt.subplots(1, 2, figsize=(12, 6))
+    plot_training_trajectory(axs[0], x_train, x_true, x_smooth)
+    axs[0].legend()
+    axs[0].set(title="Training data")
+    axs[1].loglog(np.abs(scipy.fft.rfft(x_train, axis=0)) / np.sqrt(len(x_train)))
+    axs[1].set(title="Training Data Absolute Spectral Density")
+    axs[1].set(xlabel="Wavenumber")
+    axs[1].set(ylabel="Magnitude")
     return fig
+
 
 def plot_pde_training_data(last_train, last_train_true, smoothed_last_train):
     """Plot training data (and smoothed training data, if different)."""


### PR DESCRIPTION
This pull requests adds several types to utils.py that describe aspects of data saved during a gridsearch:
- `GridPointData`: The data plotted at a single gridpoint, e.g. smoothed training data, simulations
- `PlotData`: That data along with the experimental parameters defining the gridpoint
- `SeriesData`: The summary data to plot after a gridsearch
- `Results`: summary and gridpoint data, along with other parameters (e.g. metrics, gridsearch parameter values)

Data can be loaded with `utils.load_results(hexstr)`, where `hexstr` is the XXXXX of the "results_XXXXXX.npy" files saved in a mitosis run.  The data from multiple runs or across parameters can be combined with the following functions:
- `plot_experiment_across_gridpoints`: Plot only the training or test data of a single experiment across multiple parameters
- `plot_point_across_experiments`: Plot only the training or test data of multiple experiments for a single parameter set
- `plot_summary_metric`: Combine single subplots from the summary plot (e.g. F1 score across `sim_params.t_end`) across multiple experiments
- `plot_summary_test_train`: See how different parameter choices affect  test/training data across multiple experiments

Because these are run after experiments, it's required to run complete gridsearch experiments before testing this stuff out.  These experiments need to have `plot_prefs` set in order to store any intermediate plot data.  The resulting files need to be opened and the hexstr extracted (since `mitosis` doesn't save this info in the database).

As a teaser, the functions can be called like:
```
from gen_experiments import utils

results = utils.load_results("580e49")
params = results["plot_data"][0]["params"]
utils.plot_point_across_experiments(
    params,
    ("Cubic Oscillator", "e3399c"),
    ("Duffing", "c8d97a"),
    ("Hopf", "8aa111"),
    ("Lotka-Volterra", "393bde"),
    ("Harmonic Oscillator", "46e3e1"),
    ("Van der Pol", "580e49"),
    ("Rossler", "2e7508"),
    style="training",
)
```

![image](https://github.com/Jacob-Stevens-Haas/gen-experiments/assets/37048747/4e927fc8-d049-4a46-a859-7bc84f59bb3a)

Also note that I blacked some of the existing code.  Sorry, I should have done that in a different PR