### PR TITLE
Kalman gridsearch

### DIFF
--- a/src/gen_experiments/config.py
+++ b/src/gen_experiments/config.py
@@ -421,6 +421,16 @@ series_params = {
             diff_series["sg2"],
         ],
     ),
+    "multikalman": SeriesList(
+        "diff_params",
+        "Differentiation Method",
+        [
+            diff_series["auto-kalman3"],
+            diff_series["kalman2"],
+            diff_series["tv2"],
+            diff_series["sg2"],
+        ],
+    ),
 }
 
 

--- a/src/gen_experiments/config.py
+++ b/src/gen_experiments/config.py
@@ -333,19 +333,19 @@ diff_series = {
         [np.logspace(-4, 0, 5)],
     ),
     "auto-kalman": SeriesDef(
-        "Kalman",
+        "Auto Kalman",
         diff_params["kalman"],
         ["diff_params.alpha", "diff_params.meas_var"],
         [(None,), (0.1, 0.5, 1, 2, 4, 8)],
     ),
     "auto-kalman2": SeriesDef(
-        "Kalman",
+        "Auto Kalman",
         diff_params["kalman"],
         ["diff_params.alpha", "diff_params.meas_var"],
         [(None,), (0.01, 0.25, 1, 4, 16, 64)],
     ),
     "auto-kalman3": SeriesDef(
-        "Kalman",
+        "Auto Kalman",
         diff_params["kalman"],
         ["diff_params.alpha"],
         [(None,)],


### PR DESCRIPTION
* Adds "multikalman" `series_params`, which tells gridsearch to treat Kalman auto-hyperparameter selection and Kalman Gridsearch separately
* Fixes the name of Kalman auto-hyperparameter series so that it appears correctly in final plots