### PR TITLE
Disable abs -> rel noise conversion

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,7 +36,7 @@ jobs:
         pip install -e .[dev]
     - name: run mypy
       run: |
-        mypy -v
+        mypy
 
 
   Tests:

--- a/src/gen_experiments/__init__.py
+++ b/src/gen_experiments/__init__.py
@@ -4,7 +4,6 @@ from collections.abc import Mapping
 from typing import Any
 
 import numpy as np
-from mitosis import Experiment
 from numpy.typing import NDArray
 from pysindy import BaseDifferentiation, FiniteDifference, SINDy
 
@@ -68,7 +67,7 @@ class NoExperiment:
         return metrics
 
 
-experiments: dict[str, tuple[Experiment, str | None]] = {
+experiments: dict[str, tuple[Any, str | None]] = {
     "sho": (odes, "sho"),
     "lorenz": (odes, "lorenz"),
     "lorenz_2d": (odes, "lorenz_2d"),

--- a/src/gen_experiments/__init__.py
+++ b/src/gen_experiments/__init__.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import Any
 
 import numpy as np
+from mitosis import Experiment
 from numpy.typing import NDArray
 from pysindy import BaseDifferentiation, FiniteDifference, SINDy
 
@@ -67,7 +68,7 @@ class NoExperiment:
         return metrics
 
 
-experiments = {
+experiments: dict[str, tuple[Experiment, str | None]] = {
     "sho": (odes, "sho"),
     "lorenz": (odes, "lorenz"),
     "lorenz_2d": (odes, "lorenz_2d"),

--- a/src/gen_experiments/config.py
+++ b/src/gen_experiments/config.py
@@ -3,6 +3,7 @@ from typing import TypeVar
 
 import numpy as np
 import pysindy as ps
+from numpy.typing import NDArray
 
 from gen_experiments.data import _signal_avg_power
 from gen_experiments.gridsearch.typing import (
@@ -24,8 +25,10 @@ def ND(d: dict[T, U]) -> NestedDict[T, U]:
 
 
 def _convert_abs_rel_noise(
-    grid_vals: list, grid_params: list, recent_results: FullSINDyTrialData
-):
+    grid_vals: list[NDArray[np.floating]],
+    grid_params: list[str],
+    recent_results: FullSINDyTrialData,
+) -> tuple[list[NDArray[np.floating]], list[str]]:
     """Convert abs_noise grid_vals to rel_noise"""
     signal = np.stack(recent_results["x_true"], axis=-1)
     signal_power = _signal_avg_power(signal)

--- a/src/gen_experiments/data.py
+++ b/src/gen_experiments/data.py
@@ -26,7 +26,7 @@ def gen_data(
     nonnegative: bool = False,
     dt: float = 0.01,
     t_end: float = 10,
-) -> tuple[float, Float1D, Float2D, Float2D, Float2D, Float2D]:
+) -> tuple[float, Float1D, list[Float2D], list[Float2D], list[Float2D], list[Float2D]]:
     """Generate random training and test data
 
     Note that test data has no noise.

--- a/src/gen_experiments/gridsearch/__init__.py
+++ b/src/gen_experiments/gridsearch/__init__.py
@@ -231,6 +231,7 @@ def run(
         series_searches.append((grid_optima, grid_ind))
 
     main_metric_ind = metrics.index("main") if "main" in metrics else 0
+
     results: GridsearchResultDetails = {
         "system": group,
         "plot_data": [],

--- a/src/gen_experiments/gridsearch/__init__.py
+++ b/src/gen_experiments/gridsearch/__init__.py
@@ -211,14 +211,12 @@ def run(
         gridpoint_selector = _ndindex_skinny(
             full_results_shape[1:], ind_skinny, where_others
         )
-        rng = np.random.default_rng(seed)
         for ind_counter, ind in enumerate(gridpoint_selector):
             print(f"Calculating series {s_counter}, gridpoint{ind_counter}", end="\r")
-            new_seed = rng.integers(1000)
             for axis_ind, key, val_list in zip(ind, new_grid_params, new_grid_vals):
                 curr_other_params[key] = val_list[axis_ind]
             curr_results, grid_data = base_ex.run(
-                new_seed, **curr_other_params, display=False, return_all=True
+                seed, **curr_other_params, display=False, return_all=True
             )
             intermediate_data.append(
                 {"params": curr_other_params.flatten(), "pind": ind, "data": grid_data}

--- a/src/gen_experiments/gridsearch/typing.py
+++ b/src/gen_experiments/gridsearch/typing.py
@@ -6,7 +6,6 @@ from typing import (
     Any,
     Callable,
     Collection,
-    Generic,
     Optional,
     Sequence,
     TypedDict,
@@ -83,10 +82,9 @@ SeriesData = Annotated[
 ]
 
 ExpResult = dict[str, Any]
-ExpResultVar = TypeVar("ExpResultVar", bound=ExpResult)
 
 
-class SavedGridPoint(TypedDict, Generic[ExpResultVar]):
+class SavedGridPoint(TypedDict):
     """The results at a point in the gridsearch.
 
     Args:
@@ -97,7 +95,7 @@ class SavedGridPoint(TypedDict, Generic[ExpResultVar]):
 
     params: dict
     pind: tuple[int, ...]
-    data: ExpResultVar
+    data: ExpResult
 
 
 class GridsearchResultDetails(TypedDict):

--- a/src/gen_experiments/gridsearch/typing.py
+++ b/src/gen_experiments/gridsearch/typing.py
@@ -6,6 +6,7 @@ from typing import (
     Any,
     Callable,
     Collection,
+    Generic,
     Optional,
     Sequence,
     TypedDict,
@@ -82,9 +83,10 @@ SeriesData = Annotated[
 ]
 
 ExpResult = dict[str, Any]
+ExpResultVar = TypeVar("ExpResultVar", bound=ExpResult)
 
 
-class SavedGridPoint(TypedDict):
+class SavedGridPoint(TypedDict, Generic[ExpResultVar]):
     """The results at a point in the gridsearch.
 
     Args:
@@ -95,7 +97,7 @@ class SavedGridPoint(TypedDict):
 
     params: dict
     pind: tuple[int, ...]
-    data: ExpResult
+    data: ExpResultVar
 
 
 class GridsearchResultDetails(TypedDict):

--- a/src/gen_experiments/gridsearch/typing.py
+++ b/src/gen_experiments/gridsearch/typing.py
@@ -106,8 +106,9 @@ class GridsearchResultDetails(TypedDict):
     series_data: dict[str, SeriesData]
     metrics: tuple[str, ...]
     grid_params: list[str]
-    plot_params: list[str]
-    grid_vals: list[Sequence]
+    grid_vals: list[Sequence[Any]]
+    scan_grid: dict[str, Sequence[Any]]
+    plot_grid: dict[str, Sequence[Any]]
     main: float
 
 

--- a/src/gen_experiments/odes.py
+++ b/src/gen_experiments/odes.py
@@ -154,7 +154,7 @@ ode_setup = {
 
 
 def run(
-    seed: float,
+    seed: int,
     group: str,
     sim_params: dict,
     diff_params: dict,

--- a/src/gen_experiments/plotting.py
+++ b/src/gen_experiments/plotting.py
@@ -29,7 +29,7 @@ class _PlotPrefs:
     """
 
     plot: bool = True
-    rel_noise: Literal[False] | Callable[..., tuple[list[Any], list[str]]] = False
+    rel_noise: Literal[False] | Callable[..., dict[str, Sequence[Any]]] = False
     plot_match: GridLocator = field(default_factory=lambda: GridLocator())
 
     def __bool__(self):

--- a/src/gen_experiments/plotting.py
+++ b/src/gen_experiments/plotting.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Annotated, Callable, Literal, Sequence
+from typing import Annotated, Any, Callable, Literal, Sequence
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -29,7 +29,7 @@ class _PlotPrefs:
     """
 
     plot: bool = True
-    rel_noise: Literal[False] | Callable = False
+    rel_noise: Literal[False] | Callable[..., tuple[list[Any], list[str]]] = False
     plot_match: GridLocator = field(default_factory=lambda: GridLocator())
 
     def __bool__(self):

--- a/tests/test_gridsearch.py
+++ b/tests/test_gridsearch.py
@@ -163,9 +163,9 @@ def gridsearch_results():
         "plot_data": [want, dont_want],
         "series_data": {"foo": max_amax},
         "metrics": ("mse", "mae"),
-        "grid_params": ["sim_params.t_end", "sim_params.noise"],
+        "grid_params": ["sim_params.t_end", "bar", "sim_params.noise"],
         "plot_params": ["sim_params.t_end", "sim_params.noise"],
-        "grid_vals": [[1, 2], [5, 6]],
+        "grid_vals": [[1, 2], [7, 8], [5, 6]],
         "main": 1,
     }
     return want, full_details

--- a/tests/test_gridsearch.py
+++ b/tests/test_gridsearch.py
@@ -163,8 +163,9 @@ def gridsearch_results():
         "plot_data": [want, dont_want],
         "series_data": {"foo": max_amax},
         "metrics": ("mse", "mae"),
+        "scan_grid": {"sim_params.t_end": [1, 2], "sim_params.noise": [5, 6]},
+        "plot_grid": {},
         "grid_params": ["sim_params.t_end", "bar", "sim_params.noise"],
-        "plot_params": ["sim_params.t_end", "sim_params.noise"],
         "grid_vals": [[1, 2], [7, 8], [5, 6]],
         "main": 1,
     }


### PR DESCRIPTION
This change clarifies the transition of grid params (every parameter used in all series that varies in the gridsearch) to scan params (only those that remain after argmax/argmin) to finally, plot params (those that go into final plots).  Given the removal of the ability to convert parameters after experiments, plot params are the same as scan params until that feature is re-enabled.

This also fixes the issue with different gridpoints using different simulations; thanks @yb6599 for spotting this.

To use the new branch, change the `grid_vals` and `grid_params` to use `"sim_params.rel_noise"` instead of absolute noise.

ALSO - unrelated, but can you add `unbias=True` in the MIOSR optimizer used?