### PR TITLE
Separate data generation step

### DIFF
--- a/src/gen_experiments/__init__.py
+++ b/src/gen_experiments/__init__.py
@@ -36,6 +36,10 @@ class NoExperiment:
     lookup_dict = {"arg": {"foo": 1}}
 
     @staticmethod
+    def gen_data(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    @staticmethod
     def run(
         *args: Any, return_all: bool = True, **kwargs: Any
     ) -> Scores | tuple[Scores, SINDyTrialData]:

--- a/src/gen_experiments/data.py
+++ b/src/gen_experiments/data.py
@@ -45,9 +45,8 @@ def gen_data(
         noise_rel (float): measurement noise-to-signal power ratio.
             Either noise_abs or noise_rel must be None.  Defaults to
             None.
-        nonnegative (bool): Whether x0 must be nonnegative, such as for
-            population models.  If so, a gamma distribution is
-            used, rather than a normal distribution.
+        dt: time step for sample
+        t_end: end time of simulation
 
     Returns:
         dictionary of data and descriptive information

--- a/src/gen_experiments/gridsearch/__init__.py
+++ b/src/gen_experiments/gridsearch/__init__.py
@@ -180,6 +180,8 @@ def run(
     elif base_ex.__name__ == "gen_experiments.pdes":
         plot_panel = plot_pde_panel
         data_step = gen_pde_data
+    elif base_ex.__name__ == "NoExperiment":
+        data_step = gen_experiments.NoExperiment.gen_data
     if series_params is None:
         series_params = SeriesList(None, None, [SeriesDef(group, {}, [], [])])
         legends = False
@@ -220,10 +222,12 @@ def run(
             start = process_time()
             for axis_ind, key, val_list in zip(ind, new_grid_params, new_grid_vals):
                 curr_other_params[key] = val_list[axis_ind]
-            data = data_step(seed=seed, **curr_other_params.pop("sim_params"))
+            sim_params = curr_other_params.pop("sim_params", {})
+            data = data_step(seed=seed, **sim_params)
             curr_results, grid_data = base_ex.run(
                 data, **curr_other_params, display=False, return_all=True
             )
+            curr_results["sim_params"] = sim_params
             intermediate_data.append(
                 {"params": curr_other_params.flatten(), "pind": ind, "data": grid_data}
             )

--- a/src/gen_experiments/gridsearch/__init__.py
+++ b/src/gen_experiments/gridsearch/__init__.py
@@ -17,6 +17,7 @@ from scipy.stats import kstest
 import gen_experiments
 
 from .. import config
+from ..data import gen_data, gen_pde_data
 from ..odes import plot_ode_panel
 from ..pdes import plot_pde_panel
 from ..plotting import _PlotPrefs
@@ -175,8 +176,10 @@ def run(
     base_ex, base_group = gen_experiments.experiments[group]
     if base_ex.__name__ == "gen_experiments.odes":
         plot_panel = plot_ode_panel
+        data_step = gen_data
     elif base_ex.__name__ == "gen_experiments.pdes":
         plot_panel = plot_pde_panel
+        data_step = gen_pde_data
     if series_params is None:
         series_params = SeriesList(None, None, [SeriesDef(group, {}, [], [])])
         legends = False
@@ -217,8 +220,9 @@ def run(
             start = process_time()
             for axis_ind, key, val_list in zip(ind, new_grid_params, new_grid_vals):
                 curr_other_params[key] = val_list[axis_ind]
+            data = data_step(seed=seed, **curr_other_params.pop("sim_params"))
             curr_results, grid_data = base_ex.run(
-                seed, **curr_other_params, display=False, return_all=True
+                data, **curr_other_params, display=False, return_all=True
             )
             intermediate_data.append(
                 {"params": curr_other_params.flatten(), "pind": ind, "data": grid_data}

--- a/src/gen_experiments/odes.py
+++ b/src/gen_experiments/odes.py
@@ -181,7 +181,7 @@ def run(
         x0_center=x0_center,
         nonnegative=nonnegative,
         **sim_params,
-    )
+    )["data"]
     model = make_model(input_features, dt, diff_params, feat_params, opt_params)
 
     model.fit(x_train)

--- a/src/gen_experiments/pdes.py
+++ b/src/gen_experiments/pdes.py
@@ -174,7 +174,7 @@ def run(
         noise_rel=rel_noise,
         dt=time_args[0],
         t_end=time_args[1],
-    )
+    )["data"]
     model = make_model(input_features, dt, diff_params, feat_params, opt_params)
 
     model.fit(x_train, t=t_train)

--- a/src/gen_experiments/pdes.py
+++ b/src/gen_experiments/pdes.py
@@ -3,8 +3,8 @@ import numpy as np
 import pysindy as ps
 
 from . import config
-from .data import gen_pde_data
 from .plotting import compare_coefficient_plots, plot_pde_training_data
+from .typing import ProbData
 from .utils import (
     FullSINDyTrialData,
     SINDyTrialData,
@@ -136,45 +136,21 @@ pde_setup = {
 
 
 def run(
-    seed: float,
-    group: str,
-    sim_params: dict,
+    data: ProbData,
     diff_params: dict,
     feat_params: dict,
     opt_params: dict,
     display: bool = True,
     return_all: bool = False,
 ) -> dict | tuple[dict, SINDyTrialData | FullSINDyTrialData]:
-    rhsfunc = pde_setup[group]["rhsfunc"]["func"]
-    input_features = pde_setup[group]["input_features"]
-    initial_condition = sim_params["init_cond"]
-    try:
-        rel_noise = sim_params["rel_noise"]
-    except KeyError:
-        rel_noise = 0.1
-    spatial_grid = pde_setup[group]["spatial_grid"]
-    spatial_args = [
-        (spatial_grid[-1] - spatial_grid[0]) / len(spatial_grid),
-        len(spatial_grid),
-    ]
-    time_args = pde_setup[group]["time_args"]
-    dimension = pde_setup[group]["rhsfunc"]["dimension"]
-    coeff_true = pde_setup[group]["coeff_true"]
-    try:
-        time_args = pde_setup[group]["time_args"]
-    except KeyError:
-        time_args = [0.01, 10]
-    dt, t_train, x_train, x_test, x_dot_test, x_train_true = gen_pde_data(
-        rhsfunc,
-        initial_condition,
-        spatial_args,
-        dimension,
-        seed,
-        noise_abs=None,
-        noise_rel=rel_noise,
-        dt=time_args[0],
-        t_end=time_args[1],
-    )["data"]
+    dt = data.dt
+    t_train = data.t_train
+    x_train = data.x_train
+    x_test = data.x_test
+    x_dot_test = data.x_dot_test
+    x_train_true = data.x_train_true
+    coeff_true = data.coeff_true
+    input_features = data.input_features
     model = make_model(input_features, dt, diff_params, feat_params, opt_params)
 
     model.fit(x_train, t=t_train)

--- a/src/gen_experiments/typing.py
+++ b/src/gen_experiments/typing.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import TypeVar
+from typing import NamedTuple, TypeVar
 
 import numpy as np
 from numpy.typing import NBitBase
@@ -9,6 +9,15 @@ Float1D = np.ndarray[tuple[int], NpFlt]
 Float2D = np.ndarray[tuple[int, int], NpFlt]
 Shape = TypeVar("Shape", bound=tuple[int, ...])
 FloatND = np.ndarray[Shape, np.dtype[np.floating[NBitBase]]]
+
+
+class ProbData(NamedTuple):
+    dt: float
+    t_train: Float1D
+    x_train: list[FloatND]
+    x_test: list[FloatND]
+    x_dot_test: list[FloatND]
+    x_train_true: list[FloatND]
 
 
 class NestedDict(defaultdict):

--- a/src/gen_experiments/typing.py
+++ b/src/gen_experiments/typing.py
@@ -18,6 +18,8 @@ class ProbData(NamedTuple):
     x_test: list[FloatND]
     x_dot_test: list[FloatND]
     x_train_true: list[FloatND]
+    input_features: list[str]
+    coeff_true: list[dict[str, float]]
 
 
 class NestedDict(defaultdict):

--- a/tests/test_gridsearch.py
+++ b/tests/test_gridsearch.py
@@ -238,7 +238,7 @@ def test_gridsearch_mock():
         grid_params=["foo"],
         grid_vals=[[0, 1]],
         grid_decisions=["plot"],
-        other_params={"bar": False},
+        other_params={"bar": False, "sim_params": {}},
         metrics=("mse", "mae"),
     )
     assert len(results["plot_data"]) == 0


### PR DESCRIPTION
This PR removes the `gen_data` or `gen_pde_data` from the ODE/PDE experiments, making it a fully-fledged experiment step.  gridsearch now has to dispatch the data params to the correct data generation method.  These methods are hollowed out and simply handle default parameters/lookups/guard code, with the actual data generation extracted to helper functions.

```
mitosis ode_data odes -e ode_data.group=\"lorenz\"
```