### PR TITLE
BugFix: PDE shape errors

### DIFF
--- a/src/gen_experiments/data.py
+++ b/src/gen_experiments/data.py
@@ -295,6 +295,7 @@ def _gen_pde_data(
             x_train, (t, int(np.cbrt(x)), int(np.cbrt(x)), int(np.cbrt(x)), 1)
         )
     x_test = x_train
+    signal = x_test
     x_test = np.moveaxis(x_test, -1, 0)
     x_dot_test = np.array(
         [
@@ -303,23 +304,23 @@ def _gen_pde_data(
         ]
     )
     if dimension == 1:
-        x_dot_test = [np.moveaxis(x_dot_test, [0, 1], [-1, -2])]
+        x_dot_test = np.moveaxis(x_dot_test, [0, 1], [-1, -2])
         pass
     elif dimension == 2:
         x_dot_test = np.reshape(x_dot_test, (t, int(np.sqrt(x)), int(np.sqrt(x)), 1))
-        x_dot_test = [np.moveaxis(x_dot_test, 0, -2)]
+        x_dot_test = np.moveaxis(x_dot_test, 0, -2)
     elif dimension == 3:
         x_dot_test = np.reshape(
             x_dot_test, (t, int(np.cbrt(x)), int(np.cbrt(x)), int(np.cbrt(x)), 1)
         )
-        x_dot_test = [np.moveaxis(x_dot_test, 0, -2)]
+        x_dot_test = np.moveaxis(x_dot_test, 0, -2)
     x_train_true = np.copy(x_train)
     if noise_rel is not None:
-        noise_abs = np.sqrt(_max_amplitude(x_test, axis=-2) * noise_rel)
+        noise_abs = np.sqrt(_max_amplitude(signal, axis=-2) * noise_rel)
     x_train = x_train + cast(float, noise_abs) * rng.standard_normal(x_train.shape)
-    x_train = [np.moveaxis(x_train, 0, -2)]
+    x_train = np.moveaxis(x_train, 0, -2)
     x_train_true = np.moveaxis(x_train_true, 0, -2)
-    x_test = [np.moveaxis(x_test, [0, 1], [-1, -2])]
+    x_test = np.moveaxis(x_test, [0, 1], [-1, -2])
     return dt, t_train, x_train, x_test, x_dot_test, x_train_true
 
 

--- a/src/gen_experiments/pdes.py
+++ b/src/gen_experiments/pdes.py
@@ -156,7 +156,6 @@ def run(
     model.fit(x_train, t=t_train)
     coeff_true, coefficients, feature_names = unionize_coeff_matrices(model, coeff_true)
 
-    sim_ind = -1
     trial_data: SINDyTrialData = {
         "dt": dt,
         "coeff_true": coeff_true,
@@ -165,10 +164,10 @@ def run(
         "input_features": input_features,
         "t_train": t_train,
         "x_true": x_train_true,
-        "x_train": x_train[sim_ind],
+        "x_train": x_train,
         "smooth_train": model.differentiation_method.smoothed_x_,
-        "x_test": x_test[sim_ind],
-        "x_dot_test": x_dot_test[sim_ind],
+        "x_test": x_test,
+        "x_dot_test": x_dot_test,
         "model": model,
     }
     if display:


### PR DESCRIPTION
Hey @Jacob-Stevens-Haas, while running the PDE experiments, I got the error
```
ValueError: zero-size array to reduction operation maximum which has no identity
```
which suggests that the PDE array shapes are not conforming with the experiment setup. This PR changes the PDE data shapes, removes array lists since there's only one trajectory, and adds a `signal` parameter for `noise_abs` calculation, as `x_test` needs some reshaping to compute `x_dot_test`.