### PR TITLE
fix: Allow gridsearches with no summary plots and no skinny axes.

### DIFF
--- a/src/gen_experiments/utils.py
+++ b/src/gen_experiments/utils.py
@@ -189,8 +189,8 @@ def unionize_coeff_matrices(
             # split on ops like *,^, only accept x, x2, from x * x2 ^ 2
             return {var for var in re.split(r"\W", fname) if re.match(r"[^\d]", var)}
 
-        inputs_true = set.union(*[extract_vars(fname) for fname in in_funcs])
-        inputs_true = sorted(inputs_true)
+        inputs_set = set.union(*[extract_vars(fname) for fname in in_funcs])
+        inputs_true = sorted(inputs_set)
         coeff_true = model_true
     else:
         inputs_true, coeff_true = model_true

--- a/tests/test_gridsearch.py
+++ b/tests/test_gridsearch.py
@@ -10,6 +10,18 @@ from gen_experiments.gridsearch.typing import (
 )
 
 
+def test_thick_indexing():
+    result = set(gridsearch._ndindex_skinny((2,), None, None))
+    expected = {(0,), (1,)}
+    assert result == expected
+
+
+def test_thick_indexing_alt():
+    result = set(gridsearch._ndindex_skinny((2,), [], None))
+    expected = {(0,), (1,)}
+    assert result == expected
+
+
 def test_thin_indexing():
     result = set(gridsearch._ndindex_skinny((2, 2, 2), (0, 2), ((0,), (-1,))))
     expected = {
@@ -82,6 +94,26 @@ def test_marginalize_grid_views():
     expected_ind = [
         np.array([[(0, 0, 0), (1, 1, 1)], [(0, 0, 0), (1, 1, 0)]], ts),
         np.array([[(0, 0, 0), (1, 1, 1)], [(1, 1, 0), (0, 0, 1)]], ts),
+    ]
+    for result, expected in zip(res_ind, expected_ind):
+        np.testing.assert_array_equal(result, expected)
+
+
+def test_marginalize_grid_views_noplot():
+    arr = np.array(([[0.0, 1.0], [2.0, 3.0]]))  # (metrics, param1)
+    grid_decisions = ["max"]
+    opts = ["max", "min"]
+    res_val, res_ind = gridsearch._marginalize_grid_views(grid_decisions, arr, opts)
+    assert len(res_val) == 1
+    expected_val = [
+        np.array([[1.0], [2.0]]),
+    ]
+    for result, expected in zip(res_val, expected_val):
+        np.testing.assert_array_equal(result, expected)
+
+    ts = np.dtype([("f0", "<i4")])
+    expected_ind = [
+        np.array([[(1,)], [(0,)]], ts),
     ]
     for result, expected in zip(res_ind, expected_ind):
         np.testing.assert_array_equal(result, expected)
@@ -238,6 +270,19 @@ def test_gridsearch_mock():
         grid_params=["foo"],
         grid_vals=[[0, 1]],
         grid_decisions=["plot"],
+        other_params={"bar": False, "sim_params": {}},
+        metrics=("mse", "mae"),
+    )
+    assert len(results["plot_data"]) == 0
+
+
+def test_gridsearch_mock_noplot():
+    results = gridsearch.run(
+        1,
+        "none",
+        grid_params=["foo"],
+        grid_vals=[[0, 1]],
+        grid_decisions=["max"],
         other_params={"bar": False, "sim_params": {}},
         metrics=("mse", "mae"),
     )


### PR DESCRIPTION
Previous code assumed some nonempty lists.  This assumption permeated _ndindex_skinny and _marginalize_grid_views.  Now we special-case the empty list in those functions and enforce return shape in the latter.

This is particularly useful in mock trials.