### PR TITLE
Allow passing models directly as parameters to odes.run()

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In addition, tentative PDE functionality is provided, though may be unstable:
 * `gen_experiments.pdes.run()`
 
 ## Plotting and diagnostics
-Perhaps of most significance are the SINDy diagnostic plotting.  `gen_experiments.plotting` has a variety 
+Perhaps of most significance are the SINDy diagnostic plotting.  `gen_experiments.plotting` has a variety
 of functions for creating diagnostics of fitted SINDy models:
 * `gen_experiments.plotting.compare_coefficient_plots()` and its cousin,
   `gen_experiments.utils.unionize_coeff_matrices()`, which is used to align coefficient matrices from
@@ -28,5 +28,5 @@ of functions for creating diagnostics of fitted SINDy models:
 
 
 ## Names
-This package is destributed as pysindy-experiments, while some names still refer to gen_experiments.
+This package is distributed as pysindy-experiments, while some names still refer to gen_experiments.
 The latter is due to the origins in a PhD general exam.

--- a/src/gen_experiments/odes.py
+++ b/src/gen_experiments/odes.py
@@ -249,7 +249,7 @@ def run(
         )
     model = cast(_BaseSINDy, model)
     model.feature_names = data.input_features
-    model.fit(x_train, t=dt)
+    model.fit(x_train, t=len(x_train) * t_train)
     MOD_LOG.info(f"Fitting a model: {model}")
     coeff_true, coefficients, feature_names = unionize_coeff_matrices(
         model, (data.input_features, coeff_true)

--- a/src/gen_experiments/utils.py
+++ b/src/gen_experiments/utils.py
@@ -11,7 +11,7 @@ import pysindy as ps
 import sklearn
 import sklearn.metrics
 from numpy.typing import NDArray
-from pysindy.pysindy import SINDy, _BaseSINDy
+from pysindy.pysindy import _BaseSINDy
 
 from .typing import Float1D, Float2D, FloatND
 
@@ -119,7 +119,7 @@ def pred_metrics(
     }
 
 
-def integration_metrics(model: SINDy, x_test, t_train, x_dot_test):
+def integration_metrics(model: _BaseSINDy, x_test, t_train, x_dot_test):
     metrics = {}
     metrics["mse-plot"] = model.score(
         x_test,


### PR DESCRIPTION
Because mitosis could only handle a few containers as parameters (e.g. nested dictionaries), all of these experiments were written with nested dictionaries as the parameter type. Now that mitosis allows parameters to be custom container classes, we should modify `odes.run()` (and eventually, gridsearch) to allow them: It makes updating parameter names much easier due to IDE's static code analysis.