### PR TITLE
Allow numpy >= 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,32 +22,30 @@ classifiers = [
   "Natural Language :: English",
   "Operating System :: POSIX :: Linux",
 ]
-# Since the point of the package is reproducibility, incl. all dev
-# dependencies
 dependencies = [
   "mitosis >=0.5.2",
   "derivative >=0.6.3",
-  "pysindy[cvxpy,miosr] >=2.0.0rc2",
+  "pysindy[cvxpy,miosr] >=2.0.0rc3",
   "kalman @ git+https://github.com/Jacob-Stevens-Haas/kalman@0.1.1",
   "auto_ks @ git+https://github.com/cvxgrp/auto_ks.git@e60bcc6",
-  "pytest >= 6.0.0",
-  "pytest-cov",
-  "flake8",
-  "flake8-comprehensions>=3.1.0",
   "matplotlib",
   "numpy >= 1.20.0",
-  "black",
-  "coverage",
-  "isort",
-  "pre-commit",
-  "codecov",
   "seaborn",
-  "tomli",
 ]
 
 [project.optional-dependencies]
 dev = [
   "mypy",
+  "pytest >= 6.0.0",
+  "pytest-cov",
+  "flake8",
+  "flake8-comprehensions>=3.1.0",
+  "black",
+  "coverage",
+  "isort",
+  "pre-commit",
+  "codecov",
+  "tomli",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Operating System :: POSIX :: Linux",
 ]
 dependencies = [
-  "mitosis >=0.5.2",
+  "mitosis >=0.6.1",
   "derivative >=0.6.3",
   "pysindy[cvxpy,miosr] >=2.0.0rc3",
   "kalman @ git+https://github.com/Jacob-Stevens-Haas/kalman@0.1.1",

--- a/src/gen_experiments/__init__.py
+++ b/src/gen_experiments/__init__.py
@@ -41,7 +41,7 @@ class NoExperiment:
         return {
             "data": ProbData(
                 0,
-                BORING_ARRAY,
+                BORING_ARRAY[0],
                 [BORING_ARRAY],
                 [BORING_ARRAY],
                 [BORING_ARRAY],
@@ -62,8 +62,8 @@ class NoExperiment:
         if return_all:
             trial_data: SINDyTrialData = {
                 "dt": 1,
-                "coeff_true": BORING_ARRAY[:1],
-                "coeff_fit": BORING_ARRAY[:1],
+                "coeff_true": BORING_ARRAY[:1],  # type: ignore
+                "coeff_fit": BORING_ARRAY[:1],  # type: ignore
                 # "coefficients": boring_array,
                 "feature_names": ["1"],
                 "input_features": ["x", "y"],

--- a/src/gen_experiments/data.py
+++ b/src/gen_experiments/data.py
@@ -59,7 +59,7 @@ def gen_data(
     try:
         x0_center = ode_setup[group]["x0_center"]
     except KeyError:
-        x0_center = np.zeros((len(input_features)), dtype=np.float_)
+        x0_center = np.zeros((len(input_features)), dtype=np.float64)
     try:
         nonnegative = ode_setup[group]["nonnegative"]
     except KeyError:
@@ -116,7 +116,7 @@ def _gen_data(
     t_end: float,
 ) -> tuple[float, Float1D, list[Float2D], list[Float2D], list[Float2D], list[Float2D]]:
     rng = np.random.default_rng(seed)
-    t_train = np.arange(0, t_end, dt, dtype=np.float_)
+    t_train = np.arange(0, t_end, dt, dtype=np.float64)
     t_train_span = (t_train[0], t_train[-1])
     if nonnegative:
         shape = ((x0_center + 1) / ic_stdev) ** 2

--- a/src/gen_experiments/data.py
+++ b/src/gen_experiments/data.py
@@ -9,11 +9,11 @@ import mitosis
 import numpy as np
 import scipy
 
-from .gridsearch.typing import GridsearchResultDetails
-from .odes import ode_setup
-from .pdes import pde_setup
-from .plotting import plot_training_data
-from .typing import Float1D, Float2D, ProbData
+from gen_experiments.gridsearch.typing import GridsearchResultDetails
+from gen_experiments.odes import ode_setup
+from gen_experiments.pdes import pde_setup
+from gen_experiments.plotting import plot_training_data
+from gen_experiments.typing import Float1D, Float2D, ProbData
 
 INTEGRATOR_KEYWORDS = {"rtol": 1e-12, "method": "LSODA", "atol": 1e-12}
 TRIALS_FOLDER = Path(__file__).parent.absolute() / "trials"

--- a/tests/test_gridsearch.py
+++ b/tests/test_gridsearch.py
@@ -73,7 +73,7 @@ def test_curr_skinny_specs():
 
 
 def test_marginalize_grid_views():
-    arr = np.arange(16, dtype=np.float_).reshape(
+    arr = np.arange(16, dtype=np.float64).reshape(
         2, 2, 2, 2
     )  # (metrics, param1, param2, param3)
     arr[0, 0, 0, 0] = 1000
@@ -120,7 +120,7 @@ def test_marginalize_grid_views_noplot():
 
 
 def test_argopt_tuple_axis():
-    arr = np.arange(16, dtype=np.float_).reshape(2, 2, 2, 2)
+    arr = np.arange(16, dtype=np.float64).reshape(2, 2, 2, 2)
     arr[0, 0, 0, 0] = 1000
     result = gridsearch._argopt(arr, (1, 3))
     expected = np.array(
@@ -130,7 +130,7 @@ def test_argopt_tuple_axis():
 
 
 def test_argopt_empty_tuple_axis():
-    arr = np.arange(4, dtype=np.float_).reshape(4)
+    arr = np.arange(4, dtype=np.float64).reshape(4)
     result = gridsearch._argopt(arr, ())
     expected = np.array([(0,), (1,), (2,), (3,)], dtype=[("f0", "i")])
     np.testing.assert_array_equal(result, expected)
@@ -139,7 +139,7 @@ def test_argopt_empty_tuple_axis():
 
 
 def test_argopt_int_axis():
-    arr = np.arange(8, dtype=np.float_).reshape(2, 2, 2)
+    arr = np.arange(8, dtype=np.float64).reshape(2, 2, 2)
     arr[0, 0, 0] = 1000
     result = gridsearch._argopt(arr, 1)
     expected = np.array([[(0, 0, 0), (0, 1, 1)], [(1, 1, 0), (1, 1, 1)]], dtype="i,i,i")


### PR DESCRIPTION
This change allows numpy > 2.0, including a newly released pysindy version with coordinated changes.
It also sorts some of the main/dev dependencies more correctly.