### PR TITLE
Fixing dependency on older version of PySINDy

### DIFF
--- a/src/gen_experiments/odes.py
+++ b/src/gen_experiments/odes.py
@@ -6,7 +6,7 @@ from warnings import warn
 import matplotlib.pyplot as plt
 import numpy as np
 import pysindy as ps
-from pysindy.pysindy import _BaseSINDy
+from pysindy._core import _BaseSINDy
 
 from . import config
 from .plotting import (
@@ -208,7 +208,7 @@ def run(
     diff_params: Optional[dict] = None,
     feat_params: Optional[dict] = None,
     opt_params: Optional[dict] = None,
-    model: Optional[ps.pysindy._BaseSINDy] = None,
+    model: Optional[ps._core._BaseSINDy] = None,
     display: bool = True,
     return_all: bool = False,
 ) -> dict | tuple[dict, SINDyTrialData | FullSINDyTrialData]:

--- a/src/gen_experiments/utils.py
+++ b/src/gen_experiments/utils.py
@@ -11,7 +11,7 @@ import pysindy as ps
 import sklearn
 import sklearn.metrics
 from numpy.typing import NDArray
-from pysindy.pysindy import _BaseSINDy
+from pysindy._core import _BaseSINDy
 
 from .typing import Float1D, Float2D, FloatND
 


### PR DESCRIPTION
Replacing `pysindy.pysindy` (in PySINDy <2.0.0) with `pysindy._core` when importing and using `_BaseSINDy`